### PR TITLE
Mentor's CR on rna-transcription

### DIFF
--- a/rna-transcription/lib/rna_transcription.ex
+++ b/rna-transcription/lib/rna_transcription.ex
@@ -10,27 +10,12 @@ defmodule RnaTranscription do
   @spec to_rna([char]) :: [char]
   def to_rna(dna) do
     dna_nucleotide_map = %{
-      :g => "c",
-      :c => "g",
-      :t => "a",
-      :a => "u"
+      ?G => ?C,
+      ?C => ?G,
+      ?T => ?A,
+      ?A => ?U
     }
 
-    # formats charlist input to iterable list
-    dna =
-      List.to_string(dna)
-      |> String.split("")
-      |> Enum.filter(fn value -> value !== "" end)
-      |> Enum.map(fn value -> String.downcase(value) end)
-
-    # throw away values that are not in the map
-    dna =
-      Enum.filter(dna, fn value -> Map.get(dna_nucleotide_map, String.to_atom(value)) !== nil end)
-
-    # map to rna
-    rna = Enum.map(dna, fn value -> Map.get(dna_nucleotide_map, String.to_atom(value)) end)
-
-    # format to desired output
-    Enum.join(rna, "") |> String.upcase() |> String.to_charlist()
+    Enum.map(dna, fn char -> dna_nucleotide_map[char] end)
   end
 end

--- a/rna-transcription/lib/rna_transcription.ex
+++ b/rna-transcription/lib/rna_transcription.ex
@@ -23,21 +23,12 @@ defmodule RnaTranscription do
       |> Enum.filter(fn value -> value !== "" end)
       |> Enum.map(fn value -> String.downcase(value) end)
 
-    IO.puts('post-format')
-    IO.inspect(dna)
-
     # throw away values that are not in the map
     dna =
       Enum.filter(dna, fn value -> Map.get(dna_nucleotide_map, String.to_atom(value)) !== nil end)
 
-    IO.puts('post-clean')
-    IO.inspect(dna)
-
     # map to rna
     rna = Enum.map(dna, fn value -> Map.get(dna_nucleotide_map, String.to_atom(value)) end)
-
-    IO.puts('post-rna-map')
-    IO.inspect(rna)
 
     # format to desired output
     Enum.join(rna, "") |> String.upcase() |> String.to_charlist()


### PR DESCRIPTION
This works but is working too hard (and has a lot of debug code).

Elixir has a very clean syntax for codepoints that would help here:

`?G` is the codepoint of `G`

Single quoted strings are simply lists of codepoints. Double quoted strings are the binary type from Erlang. If you use the codepoint syntax on both sides of your translation function then you can reduce this problem to an Enum.map call.
